### PR TITLE
Introduce drafter-installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 ext/
 vendor/
 composer.lock
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,7 @@ script: vendor/bin/phpunit
 after_script:
   - vendor/bin/test-reporter
   - bash <(curl -s https://codecov.io/bash)
+
+addons:
+  code_climate:
+    repo_token: c8a07ee2759b229cb3bee66fb112ef1ce95494c

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ install:
 
 before_script:
   - composer install --prefer-source --no-interaction --dev
-  - composer install-drafter
   - git config --global user.name travis-ci
   - git config --global user.email travis@example.com
 
@@ -30,7 +29,3 @@ script: vendor/bin/phpunit
 after_script:
   - vendor/bin/test-reporter
   - bash <(curl -s https://codecov.io/bash)
-
-addons:
-  code_climate:
-    repo_token: c8a07ee2759b229cb3bee66fb112ef1ce95494c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The change log itself is written the way that [keepachangelog.com](http://keepac
 
 ## [Unreleased]
 
+## [4.0.1] - 2016-09-20
+## Changed
+- Removed the cumbersome way to install drafter and added a reference to hmaus/drafter-installer
+- Renamed phpunit.xml to phpunit.xml.dist and ignored phpunit.xml so you can customize your settings
+- Slimmed down phpunit output
+
 ## [4.0.0] - 2016-08-05
 ## Changed
 - Update drafter dependency to v3.0.0 [BC]

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ PHP wrapper for [Drafter](https://github.com/apiaryio/drafter) API Blueprint Par
 Drafter-php allows you to use use the [drafter](https://github.com/apiaryio/drafter) API Blueprint Parser harness
 with your PHP application.
 
-In a nutshell: you can convert [API Blueprint](http://apiblueprint.org/) files to 
-[refract] Abstract Syntax Trees in JSON or YAML format.
+In a nutshell: you can convert [API Blueprint](http://apiblueprint.org/) files to parse result.
 
 [API Blueprint](http://apiblueprint.org/) is a webservice documentation language built on top of 
 [Markdown](https://en.wikipedia.org/wiki/Markdown).
@@ -36,37 +35,7 @@ This will install the PHP package with your application.
 Please keep in mind that **Drafter is not included**.
 
 ### Install Drafter Command Line Tool using Composer
-The Drafter repository itself has a section on [installing drafter](https://github.com/apiaryio/drafter#install) it.
-
-Another way of installing Drafter, is using a [composer script](https://getcomposer.org/doc/articles/scripts.md).  
-If you do not already have, add a `scripts` section to your root composer.json:
-
-```json
-"scripts": {
-    "post-install-cmd": [
-        "if ! [[ -d ext/drafter ]]; then echo \"### Installing drafter to ./ext; drafter bin to ./vendor/bin/ ###\"; fi",
-        "if ! [[ -d ext/drafter ]]; then git clone --branch v3.0.0 --recursive https://github.com/apiaryio/drafter.git ext/drafter; fi",
-        "if ! [[ -d vendor/bin ]]; then mkdir -p vendor/bin; fi",
-        "if ! [[ -f vendor/bin/drafter ]]; then cd ext/drafter && ./configure && make drafter; fi",
-        "if ! [[ -f vendor/bin/drafter ]]; then cd vendor/bin && ln -s ../../ext/drafter/bin/drafter drafter; fi"
-    ]
-}
-```
-
-> Note: the above example checks out a specific given tag `v3.0.0`
-
-Now run `composer install`; it should start building drafter within an `ext/` folder in your project root.
-If you want the script to put drafter somewhere else, modify every occurrence of `ext/drafter` to another one.
-
-> Note: there is an open Composer feature request for downloading binaries and 
-> compiling from source: https://github.com/composer/composer/issues/4381  
-> Update: The feature was closed without being tackled for the time being
-
-You would see this method used by default, when [contributing to drafter-php](CONTRIBUTING.md).
-Installing Drafter using composer has only been tested on **Mac OS X and Linux (Ubuntu 12)**.
-
-If you have issues or questions regarding Drafter, please turn to 
-the [Drafter repository](https://github.com/apiaryio/drafter).
+Head over to [hmaus/drafter-installer](https://github.com/hendrikmaus/drafter-installer).
 
 ## Usage of Drafter-php
 1. Get an instance of the `\DrafterPhp\DrafterInterface` implementation, `\DrafterPhp\Drafter`

--- a/RoboFile.php
+++ b/RoboFile.php
@@ -34,7 +34,6 @@ class RoboFile extends \Robo\Tasks
     {
         $this
             ->taskPHPUnit('vendor/bin/phpunit')
-            ->configFile('phpunit.xml')
             ->run();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,13 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6",
-        "symfony/process": "~2.7|~3.0"
+        "symfony/process": "^2.7|^3.1.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "codegyre/robo": "~0.7",
-        "codeclimate/php-test-reporter": "~0.3"
+        "phpunit/phpunit": "^5.0",
+        "codegyre/robo": "^0.7.2",
+        "codeclimate/php-test-reporter": "^0.3",
+        "hmaus/drafter-installer": "^1.0"
     },
     "autoload": {
         "psr-4": {
@@ -28,17 +29,19 @@
             "Hmaus\\DrafterPhp\\Tests\\": "tests"
         }
     },
+    "extra": {
+        "drafter-installer-tag": "v3.1.1"
+    },
     "scripts": {
         "clean": "rm -rf vendor/ ext/ composer.lock",
         "test": "vendor/bin/phpunit",
         "quicktest": "vendor/bin/phpunit --no-coverage",
-        "install-drafter": [
-            "if ! [[ -d ext/drafter ]]; then echo \"### Installing drafter to ./ext; drafter bin to ./vendor/bin/ ###\"; fi",
-            "if ! [[ -d ext/drafter ]]; then git clone --branch v3.0.0 --recursive https://github.com/apiaryio/drafter.git ext/drafter; fi",
-            "if ! [[ -d vendor/bin ]]; then mkdir -p vendor/bin; fi",
-            "if ! [[ -f vendor/bin/drafter ]]; then cd ext/drafter && ./configure && make drafter; fi",
-            "if ! [[ -f vendor/bin/drafter ]]; then cd vendor/bin && ln -s ../../ext/drafter/bin/drafter drafter; fi"
+        "install-drafter": "Hmaus\\Drafter\\Installer::installDrafter",
+        "post-install-cmd": [
+            "@install-drafter"
         ],
-        "post-install-cmd": "@install-drafter"
+        "post-update-cmd": [
+            "@install-drafter"
+        ]
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,8 +15,6 @@
         <log type="coverage-html" target="./build/clover-html" charset="UTF-8" yui="true" highlight="true"
              lowUpperBound="50" highLowerBound="90"/>
         <log type="coverage-clover" target="./build/logs/clover.xml"/>
-        <log type="testdox-text" target="./build/logs/testdox.txt"/>
-        <log type="testdox-text" target="php://stdout"/>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
     </logging>
 


### PR DESCRIPTION
- Removed the cumbersome way to install drafter and added a reference to hmaus/drafter-installer
- Renamed phpunit.xml to phpunit.xml.dist and ignored phpunit.xml so you can customize your settings
- Slimmed down phpunit output
