### PR TITLE
fix missing escape args

### DIFF
--- a/src/Drafter.php
+++ b/src/Drafter.php
@@ -247,7 +247,7 @@ class Drafter implements DrafterInterface
     private function getProcessCommand()
     {
         $options   = $this->transformOptions();
-        $options[] = $this->input;
+        $options[] = escapeshellarg($this->input);
 
         $command = $this->binary . ' ' . implode(' ', $options);
 
@@ -275,7 +275,7 @@ class Drafter implements DrafterInterface
             $option = $key;
 
             if ($value) {
-                $option .= '=' . $value;
+                $option .= '=' . escapeshellarg($value);
             }
 
             $processOptions[] = $option;

--- a/tests/DrafterTest.php
+++ b/tests/DrafterTest.php
@@ -149,6 +149,28 @@ class DrafterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Build the process instance using drafter but with space in file name (input and output)
+     * @expectedException \Exception
+     * @expectedExceptionMessageRegExp /unable to open file/
+     */
+    public function testBuildWithSpace()
+    {
+        $process = $this
+            ->drafter
+            ->input($this->fixturePath . 'simplest example.apib')
+            ->output($this->fixturePath . 'simplest example.json')
+            ->format('json')
+            ->type('ast')
+            ->build();
+
+        $this->assertInstanceOf(Process::class, $process);
+
+        $this
+            ->drafter
+            ->run($process);
+    }
+
+    /**
      * Test setting all supported options with correct syntax.
      */
     public function testSetAllAvailableOptions()


### PR DESCRIPTION
Today when we use file with space inside, there is an error. This fix (with unit test about it) escape the option of the command line used.

thanks