### PR TITLE
Update drafter to 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The change log itself is written the way that [keepachangelog.com](http://keepac
 
 ## [Unreleased]
 
+## [6.0.0] - 2019-11-24
+## Changed
+- Update drafter dependency to v4.0.2 [BC]
+- Removed `type` option
+
 ## [5.0.1] - 2018-07-20
 ## Fixed
 - Allow spaces in filenames

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         }
     },
     "extra": {
-        "drafter-installer-tag": "v3.1.1"
+        "drafter-installer-tag": "v4.0.2"
     },
     "scripts": {
         "clean": "rm -rf vendor/ ext/ composer.lock",

--- a/src/Drafter.php
+++ b/src/Drafter.php
@@ -107,13 +107,6 @@ class Drafter implements DrafterInterface
         return $this;
     }
 
-    public function type($type)
-    {
-        $this->options['--type'] = $type;
-
-        return $this;
-    }
-
     public function sourcemap()
     {
         $this->options['--sourcemap'] = '';

--- a/src/DrafterInterface.php
+++ b/src/DrafterInterface.php
@@ -50,21 +50,6 @@ interface DrafterInterface
     public function format($format);
 
     /**
-     * Set type option.
-     *
-     * Available types:
-     *   * refract (default)
-     *   * ast
-     *
-     * Help:
-     *   -t, --type            type of the AST (refract|ast) (string [=refract])
-     *
-     * @param string $type type to retrieve, e.g. refract or ast
-     * @return $this
-     */
-    public function type($type);
-
-    /**
      * Set sourcemap argument.
      *
      * Drafter will export sourcemap in the Parse Result

--- a/tests/DrafterTest.php
+++ b/tests/DrafterTest.php
@@ -83,30 +83,11 @@ class DrafterTest extends \PHPUnit_Framework_TestCase
     /**
      * Parse a simple example to json ast.
      */
-    public function testParseSimplestAstExampleToJson()
+    public function testParseSimplestExampleToJson()
     {
         $json = $this
             ->drafter
             ->input($this->fixturePath . 'simplest-example.apib')
-            ->type('ast')
-            ->format('json')
-            ->run();
-
-        $this->assertNotNull($json);
-        $this->assertJson($json);
-
-        return $this->drafter;
-    }
-
-    /**
-     * Parse a simple example to json ast.
-     */
-    public function testParseSimplestRefractExampleToJson()
-    {
-        $json = $this
-            ->drafter
-            ->input($this->fixturePath . 'simplest-example.apib')
-            ->type('refract')
             ->format('json')
             ->run();
 
@@ -120,7 +101,8 @@ class DrafterTest extends \PHPUnit_Framework_TestCase
      * The drafter instance will hold its state; we can invoke `run` again for the same result.
      *
      * @param Drafter $drafter
-     * @depends testParseSimplestAstExampleToJson
+     * @depends testParseSimplestExampleToJson
+     * @throws \Exception
      */
     public function testRunningDrafterAgainWithoutReset(Drafter $drafter)
     {
@@ -136,7 +118,6 @@ class DrafterTest extends \PHPUnit_Framework_TestCase
             ->drafter
             ->input($this->fixturePath . 'simplest-example.apib')
             ->format('json')
-            ->type('ast')
             ->build();
 
         $this->assertInstanceOf(Process::class, $process);
@@ -160,7 +141,6 @@ class DrafterTest extends \PHPUnit_Framework_TestCase
             ->input($this->fixturePath . 'simplest example.apib')
             ->output($this->fixturePath . 'simplest example.json')
             ->format('json')
-            ->type('ast')
             ->build();
 
         $this->assertInstanceOf(Process::class, $process);


### PR DESCRIPTION
Hello Hendrik, I would like to update the whole chain to Drafter 4. The `type` option was removed which mainly caused trouble. Could you have a look, merge and release? Hope, you're well!