### PR TITLE
Added escapeshellarg and Symfony 5 to Drafter.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6",
-        "symfony/process": "^2.7|^3.1.4|^4"
+        "symfony/process": "^2.7|^3.1.4|^4|^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/Drafter.php
+++ b/src/Drafter.php
@@ -242,7 +242,7 @@ class Drafter implements DrafterInterface
         $options   = $this->transformOptions();
         $options[] = escapeshellarg($this->input);
 
-        $command = $this->binary . ' ' . implode(' ', $options);
+        $command = escapeshellarg($this->binary) . ' ' . implode(' ', $options);
 
         return $command;
     }


### PR DESCRIPTION
To allow the Drafter binary to be run from paths with spaces and parenthesis in them, `escapeshellarg` was added around the binary variable to src/Drafter.php.

This should resolve issue #10.