### PR TITLE
Fix build command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.6",
-        "symfony/process": "^2.7|^3.1.4|^4|^5"
+        "symfony/process": "^4|^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/src/Drafter.php
+++ b/src/Drafter.php
@@ -139,7 +139,7 @@ class Drafter implements DrafterInterface
     {
         $this->validateOptionsAndArguments();
 
-        $process = new Process(
+        $process = Process::fromShellCommandline(
             $this->getProcessCommand()
         );
 


### PR DESCRIPTION
Moin Hendrik,

we need to update the build command to use the static factory method `Process::fromShellCommandline`.  In `symfony/process` v4 the process constructor deprecated strings as commands and v5 doesn't support it at all anymore. This means removing support for v2 and v3 since `fromShellCommandline` wasn't available back then. OK with that?

Note: `composer install` in this package will load `symfony/process` v4 because `consolidation/robo` isn't compatible with v5.

Cheers!